### PR TITLE
Remove Lade

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,6 @@ Free tier of Heroku Dynos, Postgres and Data for Redis will no longer be availab
 | [dokku.com](https://dokku.com/) | An open source PAAS alternative to Heroku. |
 | [domcloud.co](https://domcloud.co/) | It's like those modern hosting platforms, but for the old school. |
 | [koyeb.com](https://www.koyeb.com) | For deploying full stack apps and APIs globally. Enjoy high-end performance thanks to fully automated deployments to BareMetal servers and our built-in edge network. |
-| [lade.io](https://www.lade.io/) | Deploy your apps and databases globally. |
 | [netlify.com](https://www.netlify.com/) | Free static site hosting with GitHub integration |
 | [northflank.com](https://www.northflank.com/) | Deploy any code, job, or database in seconds. |
 | [qoddi.com](https://qoddi.com/) | Qoddi is a fully managed App Hosting Platform running on a tier 1 network at 10% of the cost of similar solutions. |


### PR DESCRIPTION
The free tier has been removed due to unsustainable server costs. See https://www.lade.io/pricing.